### PR TITLE
Bug Fix

### DIFF
--- a/termtalk/receiver.py
+++ b/termtalk/receiver.py
@@ -1,9 +1,8 @@
 import pyrebase
 import os
 import platform
-from colorama import Fore, Style
+from colorama import Fore
 import json
-import random
 
 # import credential hehe
 script_dir = os.path.dirname(os.path.abspath(__file__))

--- a/termtalk/receiver.py
+++ b/termtalk/receiver.py
@@ -38,7 +38,7 @@ def receive_message():
         if result:
             messages = list(result['messages'].items())
             last_key, main_val = messages[-1]
-            color = main_val['color']
+            color = main_val['color'] if 'color' in main_val.keys() else 1
 
             if last_key != latest_msg:
                 print(f"{colors[color]}{main_val['username']}: {Fore.WHITE}{main_val['message']}")


### PR DESCRIPTION
## What Bug?

i'm encountered a bug when lower version of [Termtalk](https://pypi.org/project/termtalk/) send a message, it doesn't include any `color` parameter so the code would get an error. Now, everytime the Termtalk `versions >= 0.2.1` send a message; i will set the `color` of their names into green _(default)